### PR TITLE
In order to properly map admin rights to created namespaces, operator…

### DIFF
--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -30,12 +30,21 @@ rules:
   - watch
   - delete
 - apiGroups:
-  - authorization.openshift.io/v1
   - rbac.authorization.k8s.io
   resources:
   - rolebindings
   verbs:
   - create
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterroles
+  verbs:
+  - bind
+  resourceNames:
+  - admin
+  - edit
+  - view
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
… must have bind permission

Without this, the creation of role bindings n the new projects will fail with
```
... ,"error":"rolebindings.rbac.authorization.k8s.io \"admin\" is forbidden: attempt to grant extra privileges: ...
```